### PR TITLE
Mismatch of weight matrix shape solved.

### DIFF
--- a/test_seq2seq.py
+++ b/test_seq2seq.py
@@ -67,7 +67,9 @@ class ChatBot(object):
         decoder_outputs = decoder_dense(decoder_outputs)
 
         self.model = Model([encoder_inputs, decoder_inputs], decoder_outputs)
-        self.model.load_weights('E:/chatbot/ChatCrazie/support files/word-glove-weights.h5')
+        # The shape of weight matrix we are trying to load didnt correspond to the shape of the model 
+        # The reason is that the weights you save after training and testing were different.
+        self.model.load_weights('support files/model-weights.h5')
         self.model.compile(optimizer='rmsprop', loss='categorical_crossentropy')
 
         self.encoder_model = Model(encoder_inputs, encoder_states)


### PR DESCRIPTION
There is a bug in line 70 of test_seq2seq.py file. 

While running the test function, shape mismatch error would be thrown, as the shape of weight matrix we are trying to load doesnt correspond to the shape of the model built in train_seq2seq.py. The reason is that the weights you save after training and the weights you try to load for testing are different. The fix corrects the model file to the trained model to solve the issue.